### PR TITLE
IDR: use downloaded ansible templates & variables to configure infra

### DIFF
--- a/idr-compose.yml
+++ b/idr-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+services:
+  redis:
+    image: redis
+  # Used until omero-server-docker can configure ports
+  redirect:
+    build: idr/redirect
+  omero:
+    build: idr/omero
+    environment:
+      - ROOTPASS=${ROOTPASS}
+      - CONFIG_omero_upgrades_url=
+      - CONFIG_Ice_IPv6=0
+      - PYTHONPATH=/opt/omero/server/OMERO.server/lib/python
+      - CONFIG_omero_db_name=2018-02-12
+      - CONFIG_omero_db_host=redirect
+      - CONFIG_omero_db_user=postgres
+      - CONFIG_omero_data_dir=/OMERO
+    ports:
+      - "${OMERO_SERVER_TCP}4063"
+      - "${OMERO_SERVER_SSL}4064"
+    volumes:
+      - /uod/idr/filesets:/uod/idr/filesets:ro
+      - ./idr/omero/playbook.yml:/opt/setup/idr.yml:ro
+      - ./idr/40-ansible.sh:/startup/40-ansible.sh
+      - ./idr/70-reset-password.sh:/startup/70-reset-password.sh:ro
+  web:
+    build: idr/web
+    environment:
+      - CONFIG_omero_upgrades_url=
+      - CONFIG_Ice_IPv6=0
+      - PYTHONPATH=/opt/omero/web/OMERO.web/lib/python
+    ports:
+      - "${OMERO_WEB_PORT}4080"
+    volumes:
+      - ./idr/web/playbook.yml:/opt/setup/idr.yml:ro
+      - ./idr/40-ansible.sh:/startup/40-ansible.sh

--- a/idr/40-ansible.sh
+++ b/idr/40-ansible.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+ansible-playbook \
+        -i localhost \
+	-e retry_files_enabled=False \
+	-e ansible_connection=local \
+	-e ansible_gather_facts=False \
+	idr.yml

--- a/idr/70-reset-password.sh
+++ b/idr/70-reset-password.sh
@@ -1,0 +1,1 @@
+echo reset password

--- a/idr/omero/Dockerfile
+++ b/idr/omero/Dockerfile
@@ -1,0 +1,3 @@
+FROM openmicroscopy/omero-server:5.4
+
+# no-op

--- a/idr/omero/playbook.yml
+++ b/idr/omero/playbook.yml
@@ -1,0 +1,32 @@
+---
+- hosts: localhost
+  vars:
+    omero_db_host_ansible: redirect
+    omero_server_role_release: 2.0.4
+    idr_deployment_release: IDR-0.4.5
+
+  tasks:
+
+    - file:
+        state: directory
+        path: /tmp/idr/
+
+    - get_url:
+        url: https://raw.githubusercontent.com/openmicroscopy/ansible-role-omero-server/{{ omero_server_role_release }}/defaults/main.yml
+        dest: /tmp/idr/omero-server-defaults.yml
+
+    - get_url:
+        url: "{{ item }}"
+        dest: "/tmp/idr"
+      with_items:
+        - https://raw.githubusercontent.com/IDR/deployment/{{ idr_deployment_release }}/ansible/group_vars/omero-hosts.yml
+        - https://raw.githubusercontent.com/openmicroscopy/ansible-role-omero-server/{{ omero_server_role_release }}/templates/00-omero-server-omero.j2
+
+    - include_vars: /tmp/idr/omero-server-defaults.yml
+
+    - include_vars: /tmp/idr/omero-hosts.yml
+
+    - template:
+        dest: "/opt/omero/server/config/10-idr-server.omero"
+        src: /tmp/idr/00-omero-server-omero.j2
+        force: yes

--- a/idr/redirect/Dockerfile
+++ b/idr/redirect/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:centos7
+
+RUN yum install -y socat
+
+# To redirect all port 80 conenctions to ip 202.54.1.5, enter:
+ENTRYPOINT socat TCP-LISTEN:5432,fork TCP:beluga.openmicroscopy.org:5433

--- a/idr/web/Dockerfile
+++ b/idr/web/Dockerfile
@@ -1,0 +1,5 @@
+FROM openmicroscopy/omero-web-standalone:5.4
+
+USER root
+RUN /opt/omero/web/venv/bin/pip install omero-mapr
+USER omero-web

--- a/idr/web/playbook.yml
+++ b/idr/web/playbook.yml
@@ -1,0 +1,45 @@
+---
+- hosts: localhost
+  vars:
+    omero_redis_host_ansible: redis
+    omero_web_role_release: 1.0.2
+    omero_web_apps_role_release: 0.1.0
+    idr_deployment_release: IDR-0.4.5
+
+  tasks:
+
+    - file:
+        state: directory
+        path: /tmp/idr/
+
+    - get_url:
+        url: https://raw.githubusercontent.com/openmicroscopy/ansible-role-omero-web/{{ omero_web_role_release }}/defaults/main.yml
+        dest: /tmp/idr/omero-web-defaults.yml
+
+    - get_url:
+        url: https://raw.githubusercontent.com/openmicroscopy/ansible-role-omero-web-apps/{{ omero_web_apps_role_release }}/defaults/main.yml
+        dest: /tmp/idr/omero-web-apps-defaults.yml
+
+    - get_url:
+        url: "{{ item }}"
+        dest: "/tmp/idr"
+      with_items:
+        - https://raw.githubusercontent.com/IDR/deployment/{{ idr_deployment_release }}/ansible/group_vars/omero-hosts.yml
+        - https://raw.githubusercontent.com/openmicroscopy/ansible-role-omero-web/{{ omero_web_role_release }}/templates/00-omero-web-omero.j2
+        - https://raw.githubusercontent.com/openmicroscopy/ansible-role-omero-web-apps/{{ omero_web_apps_role_release }}/templates/omero-web-apps-omero.j2
+
+    - include_vars: /tmp/idr/omero-web-defaults.yml
+
+    - include_vars: /tmp/idr/omero-web-apps-defaults.yml
+
+    - include_vars: /tmp/idr/omero-hosts.yml
+
+    - template:
+        dest: "/opt/omero/web/config/10-idr-web.omero"
+        src: /tmp/idr/00-omero-web-omero.j2
+        force: yes
+
+    - template:
+        dest: "/opt/omero/web/config/20-idr-apps.omero"
+        src: /tmp/idr/omero-web-apps-omero.j2
+        force: yes


### PR DESCRIPTION
In order to not reproduce the configuration necessary for setting up
an IDR clone within omero-testinfra, ansible is used to download the
template files as well as the default variables from various roles &
the variables are downloaded from idr/deployment. The performance of
mapr calls is slow without nginx caching, but the timeout looks near
long enough to allow most calls to succeed.