### PR TITLE
Make persist.sh seLinux friendly

### DIFF
--- a/persist.sh
+++ b/persist.sh
@@ -24,7 +24,7 @@ function backup_volume {
   volume_name=$1
   backup_destination=$2
   echo "Backup $volume_name to $backup_destination"
-  docker run --rm -v $volume_name:/data -v $backup_destination:/backup ubuntu tar -zcf /backup/$volume_name.tar /data
+  docker run --rm -v $volume_name:/data -v $backup_destination:/backup:Z ubuntu tar -zcf /backup/$volume_name.tar /data
 }
 
 function restore_volume {
@@ -32,7 +32,7 @@ function restore_volume {
   backup_destination=$2
   echo "Restore $volume_name from $backup_destination"
   docker run --rm -v $volume_name:/data ubuntu find /data -mindepth 1 -delete
-  docker run --rm -v $volume_name:/data -v $backup_destination:/backup ubuntu tar -xf /backup/$volume_name.tar -C .
+  docker run --rm -v $volume_name:/data -v $backup_destination:/backup:Z ubuntu tar -xf /backup/$volume_name.tar -C .
 }
 
 function main {


### PR DESCRIPTION
Without this fix, the script will fail with seLinux enabled, the `:Z` option on the volumes allows running the script on Linux distributions with seLinux enabled, e.g. Fedora / Redhat / Centos.  https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/