### PR TITLE
cap pycodestyle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flake8
 pep8-naming
-pycodestyle
+pycodestyle<2.4.0
 restructuredtext_lint
 pytest==3.3.2
 restview


### PR DESCRIPTION
cap pycodestyle

See https://github.com/PyCQA/pycodestyle/issues/741
cc @joshmoore 
https://travis-ci.org/jburel/omero-parade/builds/365548744 is green now using that branch