### PR TITLE
Expose PLUGIN environment variable

### DIFF
--- a/docker
+++ b/docker
@@ -101,7 +101,7 @@ run() {
         if [ "$LOCAL" == true ]; then
             $ACTION $LOCALPREFIX/$ARGUMENT
         else
-            $ACTION docker exec $CALLAS -e TARGET=$TARGET -e OMERO_DIST=$OMERO_DIST $CID $PREFIX/$ARGUMENT
+            $ACTION docker exec $CALLAS -e TARGET=$TARGET -e PLUGIN=$PLUGIN -e OMERO_DIST=$OMERO_DIST $CID $PREFIX/$ARGUMENT
         fi
         fold end $file
     fi

--- a/docker
+++ b/docker
@@ -13,6 +13,7 @@ export VERBOSE=${VERBOSE:-"set +x"}
 export PROJECT=${PROJECT:-$(get_project_name)}
 export NETWORK=${NETWORK:-"$PROJECT"_default}
 export TARGET=/$(basename $PWD)
+export PLUGIN=${PLUGIN:-}
 
 if [ $# -eq 0 ]; then
     echo "docker [stage [stage [stage]]]"
@@ -30,6 +31,7 @@ if [ $# -eq 0 ]; then
     echo "  ACTION  - use 'echo' to perform a dry-run ($ACTION)"
     echo "  TRAVIS  - whether to print travis_folds ($TRAVIS)"
     echo "  VERBOSE - set to 'set -x' to see all actions ($VERBOSE)"
+    echo "  PLUGIN  - name of the plugin (optional) ($PLUGIN)"
     exit 2
 else
     STAGES="$@"

--- a/py-setup
+++ b/py-setup
@@ -7,6 +7,7 @@ set -u
 set -x
 
 TARGET=${TARGET:-..}
+PLUGIN=${PLUGIN:-}
 
 cd $TARGET
 cd $(setup_dir)


### PR DESCRIPTION
See https://github.com/ome/omero-metadata/pull/2

By default the `cli-build` guesses the name of the plugin from the repository name i.e. `omero-cli-<PLUGIN>`. If the repository name does not match this scheme, a `PLUGIN` variable allows to override the guess.

When using omero-test-infra with Travis, the `PLUGIN` variable is not propagated through the stack leading to incorrect guess - see https://travis-ci.org/ome/omero-metadata/builds/402142739. This PR makes the necessary changes to expose and propagate the value of `PLUGIN`