### PR TITLE
Python check unification

### DIFF
--- a/cli-build
+++ b/cli-build
@@ -14,4 +14,4 @@ export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 $OMERO_DIST/bin/omero $PLUGIN -h
 
 export PYTHONPATH=${OMERO_DIST}/lib/python
-python setup.py test -t test/integration/clitest -i ${OMERO_DIST}/etc/ice.config -v
+python setup.py test -t test/integration -i ${OMERO_DIST}/etc/ice.config -v

--- a/docker
+++ b/docker
@@ -172,7 +172,7 @@ for STAGE in $STAGES; do
             start_up
             install
             wait_on_login
-            run py update
+            run py common
             run py check
             run py setup
             run --user cli build
@@ -203,7 +203,7 @@ for STAGE in $STAGES; do
             run scripts copy
             wait_on_login
             run --user test data || echo ignore
-            run py update
+            run py common
             run --user scripts build
             ;;
         srv)

--- a/docker
+++ b/docker
@@ -173,6 +173,7 @@ for STAGE in $STAGES; do
             install
             wait_on_login
             run py update
+            run py check
             run py setup
             run --user cli build
             ;;

--- a/py-common
+++ b/py-common
@@ -7,5 +7,5 @@ TARGET=${TARGET:-..}
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd $TARGET
 
-pip install --upgrade pip setuptools
+pip install --upgrade setuptools
 pip install -r $dir/requirements.txt

--- a/py-update
+++ b/py-update
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-set -u
-set -x
-
-pip install --upgrade setuptools


### PR DESCRIPTION
While reviewing the phases executed on CLI plugins, I realized that the Python quality tools like `flake8` are currently not executed.

The changes of this PR are the following:
- adding `py-check` to the CLI entrypoint so that all OMERO CLI plugins are validated by flake8 when executing `cli-docker` /cc @dominikl
- unifying `py-common` and `py-update` which seem to be doing the same apart from 1- `pip install --upgrade pip` which has all kind of caveats as we saw recently, 2- `pip install requirements.txt` which is necessary for installing `flake8`
- expand `cli-build` test scope to run all tests under `test/integration`

Searching  https://github.com/search?p=2&q=user%3Aome+user%3Aopenmicroscopy+omero-test-infra+filename%3A.travis.yml&type=Code, there are currently 4 repos which might be affected by the changes of the `cli` and `script` phases:

-  [ome/scripts](https://github.com/ome/scripts/) CI is unmodified by this change - see https://travis-ci.org/sbesson/scripts/builds/414110835
-  [ome/omero-cli-duplicate](https://github.com/ome/omero-cli-duplicate/) CI is unmodified by this change - see https://travis-ci.org/sbesson/omero-cli-duplicate/builds/414111412
- ome/omero-cli-render#12 fixes `omero-cli-render` to be `flake8` compliant
- ome/omero-metadata#4 fixes `omero-metadata` to be `flake8` compliant and execute all integration tests

Proposed tag: `0.3.6`