### PR TITLE
Add setup command for testing external apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ recommended to use
 where NAME is `app`, `cli`, `lib` or `scripts`. The special `srv`
 command will build the parent directory as a replacement for the
 OMERO.server container.
+The `setup` command can be used to setup a server for testing external applications using your own scripts.
+For example, run `NOCLEAN=true OMERO_SERVER_SSL=4064: .omero/docker setup` and connect to `localhost:4064`.
 
 It is also possible to combine several application e.g.
 

--- a/docker
+++ b/docker
@@ -214,6 +214,16 @@ for STAGE in $STAGES; do
             run py common
             run --user scripts build
             ;;
+        setup)
+            export COMPONENT=server
+            export USER=omero-server
+            export CID="$PROJECT"_omero_1
+            export OMERO_DIST="/opt/omero/server/OMERO.server"
+            start_up
+            install
+            wait_on_login
+            run --user omero init
+            ;;
         srv)
             export COMPONENT=server
             export USER=omero-server

--- a/omero-init
+++ b/omero-init
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "No initialisation required"


### PR DESCRIPTION
When testing external clients it is useful to have an OMERO server without having to integrate the full test process into omero-test-infra.

See for example https://github.com/ome/omero-prometheus-tools/pull/4