### PR TITLE
Fix incorrect relative/absolute path with localprefix

### DIFF
--- a/docker
+++ b/docker
@@ -89,7 +89,7 @@ run() {
         fold start $file
         if [ -e .omeroci/$file ]; then
             PREFIX=/$TARGET
-            LOCALPREFIX=""
+            LOCALPREFIX="."
             ARGUMENT=.omeroci/$file
         elif [ -e $(dirname "$0")/$file ]; then
             PREFIX=/infra


### PR DESCRIPTION
Without this `.omeroci/lib-test` is run locally as `/.omeroci/lib-test` which fails since it's an absolute path