### PR TITLE
Run setup.py test against entire test folder

### DIFF
--- a/cli-build
+++ b/cli-build
@@ -14,4 +14,4 @@ export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 $OMERO_DIST/bin/omero $PLUGIN -h
 
 export PYTHONPATH=${OMERO_DIST}/lib/python
-python setup.py test -t test/integration -i ${OMERO_DIST}/etc/ice.config -v
+python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs

--- a/scripts-build
+++ b/scripts-build
@@ -7,4 +7,4 @@ set -x
 
 cd $TARGET
 
-python setup.py test -t test/integration -i ${OMERO_DIST}/etc/ice.config -v
+python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -v


### PR DESCRIPTION
At the moment, only the content of test/integration is discovered in the test
phase of the Travis CI build for plugins/apps. Discovering other types of
tests, typically unit tests, should be harmless.
In terms of testing time, migrating testing logic to unit tests rather than
integration tests should allow a more thorough coverage while limiting
execution time.