### PR TITLE
Add dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ Update the plugin with local changes:
 ```
 .omero/docker dev install
 ```
-Run the linter and tests
+Run the linter, install, run tests
 ```
 .omero/docker dev run py check
+.omero/docker dev run py setup
 .omero/docker dev run --user cli build
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ for interacting with the services started by omero-test-infra:
 Developer mode
 --------------
 
-When developing a plugin it can be useful to run part of the OMERO-test-infra scripts instead of recreating the full docker infrastructure each time.
+When developing a plugin it can be useful to run part of the OMERO-test-infra
+scripts instead of recreating the full docker infrastructure each time.
 A special `dev` command is available to modify an existing running server.
 Examine the [`docker`](docker) script for available commands.
 For example:
@@ -141,7 +142,9 @@ Run the linter, install, run tests
 .omero/docker dev run py setup
 .omero/docker dev run --user cli build
 ```
-Remember, you may need to set some environment variables to ensure your plugin is discovered and tested correctly.
+Remember, you may need to set some environment variables to ensure your plugin
+is discovered and tested correctly.
+
 If you are modifying an existing plugin see `.travis.yml` for the required variables.
 
 You can also obtain a `bash` shell in the server:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,33 @@ for interacting with the services started by omero-test-infra:
  * `download.sh` downloads and unpacks a zip file containing
    persisted tarballs.
 
+Developer mode
+--------------
+
+When developing a plugin it can be useful to run part of the OMERO-test-infra scripts instead of recreating the full docker infrastructure each time.
+A special `dev` command is available to modify an existing running server.
+Examine the [`docker`](docker) script for available commands.
+For example:
+
+Start the server with `NOCLEAN=true`:
+```
+NOCLEAN=true VERBOSE='set -x' .omero/docker
+```
+Update the plugin with local changes:
+```
+.omero/docker dev install
+```
+Run the linter and tests
+```
+.omero/docker dev run py check
+.omero/docker dev run --user cli build
+```
+
+You can also obtain a `bash` shell in the server:
+```
+.omero/docker dev sh
+```
+
 Examples
 --------
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For example:
 
 Start the server with `NOCLEAN=true`:
 ```
-NOCLEAN=true VERBOSE='set -x' .omero/docker
+NOCLEAN=true .omero/docker cli
 ```
 Update the plugin with local changes:
 ```
@@ -141,6 +141,8 @@ Run the linter, install, run tests
 .omero/docker dev run py setup
 .omero/docker dev run --user cli build
 ```
+Remember, you may need to set some environment variables to ensure your plugin is discovered and tested correctly.
+If you are modifying an existing plugin see `.travis.yml` for the required variables.
 
 You can also obtain a `bash` shell in the server:
 ```

--- a/docker
+++ b/docker
@@ -34,7 +34,14 @@ if [ $# -eq 0 ]; then
     echo "  VERBOSE - set to 'set -x' to see all actions ($VERBOSE)"
     echo "  NOCLEAN - set to 'true' to prevent container cleanup"
     echo "  PLUGIN  - name of the plugin (optional) ($PLUGIN)"
+    echo
+    echo "Development mode:"
+    echo "  dev ... - run an internal command with args"
+    echo "  dev sh  - start a shell inside the server container"
     exit 2
+elif [ "$1" = dev ]; then
+    STAGES=dev
+    shift
 else
     STAGES="$@"
 fi
@@ -138,6 +145,10 @@ wait_on_login() {
     $ACTION docker exec $OMERO_HOST $CID /infra/wait-on-login
 }
 
+sh() {
+    $ACTION docker exec -it $CID bash
+}
+
 ##
 ## RUN STAGES
 ##
@@ -233,6 +244,14 @@ for STAGE in $STAGES; do
             export OMERO_DIST="/src/dist"
             install --nosrc
             run --user srv test
+            ;;
+
+        dev)
+            export COMPONENT=server
+            export USER=omero-server
+            export CID="$PROJECT"_omero_1
+            export OMERO_DIST="/opt/omero/server/OMERO.server"
+            "$@"
             ;;
         *)
             echo "Unknown stage: $STAGE"


### PR DESCRIPTION
Add a `dev` command so developers can iteratively update and test plugins. See the README for examples.