### PR TITLE
Allow overriding BUILD_IMAGE for srv build

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,6 @@ OMERO_SERVER_SSL=
 OMERO_WEB_IMAGE=openmicroscopy/omero-web-standalone
 OMERO_WEB_VERSION=5.4
 OMERO_WEB_PORT=
+
+# srv-compose.yml related values
+BUILD_IMAGE

--- a/.env
+++ b/.env
@@ -13,4 +13,4 @@ OMERO_WEB_VERSION=5.4
 OMERO_WEB_PORT=
 
 # srv-compose.yml related values
-BUILD_IMAGE
+BUILD_IMAGE=openjdk:8

--- a/docker
+++ b/docker
@@ -227,7 +227,7 @@ for STAGE in $STAGES; do
             wait_on_login --localhost
 
             # Now that the server is running, test it
-            export USER=omero
+            export USER=1000
             export CID="$PROJECT"_test_1
             export TARGET="/src"
             export OMERO_DIST="/src/dist"

--- a/srv-compose.yml
+++ b/srv-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: ..
       target: run
+      args:
+        - BUILD_IMAGE
     environment:
       - ROOTPASS=${ROOTPASS}
       - CONFIG_omero_db_user=postgres
@@ -24,5 +26,7 @@ services:
     build:
       context: ..
       target: build
+      args:
+        - BUILD_IMAGE
     stdin_open: true
     tty: true


### PR DESCRIPTION
With this change, the following usage will use a different
base image which can include built SNAPSHOT jars for testing:

```
env BUILD_IMAGE=omero-build .omero/compose srv
```

see: https://github.com/openmicroscopy/openmicroscopy/pull/5968